### PR TITLE
FIX-axios-https

### DIFF
--- a/client/src/auth/auth-request-api/index.js
+++ b/client/src/auth/auth-request-api/index.js
@@ -4,7 +4,7 @@
 import axios from 'axios';
 axios.defaults.withCredentials = false;
 const api = axios.create({
-    baseURL: 'http://ec2-3-94-193-80.compute-1.amazonaws.com:3000'
+    baseURL: 'httsp://ec2-3-94-193-80.compute-1.amazonaws.com:3000'
 });
 
 // THESE ARE ALL THE REQUESTS WE`LL BE MAKING, ALL REQUESTS HAVE A


### PR DESCRIPTION
axios baseURL is https instead of http. This is to match the production webapp URL, which is loaded via HTTPS. A console error required this change